### PR TITLE
Enable rts workflows

### DIFF
--- a/scripts/celery-workflowmgr.py
+++ b/scripts/celery-workflowmgr.py
@@ -5,7 +5,6 @@ from katsdpdata import FileMgrClient
 
 from katsdpworkflow.RTS import qualification_tests
 from katsdpworkflow.KAT7 import pipelines
- d
 from urlparse import urlparse
 
 from optparse import OptionParser
@@ -73,8 +72,10 @@ class OODTWorkflowManager(WorkflowManagerXMLRPCServer):
         return data_store_ref, product_metadata
 
     def RTSTelescopeProductReduce(self, metadata):
-        product = self.filemgr.get_product_by_name(metadata['ProductName'][0])
-        data_store_ref = self._get_product_ref_from_filemgr(product)
+        data_store_ref, dummy_get = self._get_product_info_from_filemgr(metadata)
+        #client call for this method already  contains a call to the file manager
+        logging.info('RTSTelescopeProduct clien call with own specified reduction name')
+        logging.info('Reduction Name: %s' % (metadata['ReductionName'][0]))
         qualification_tests.run_qualification_tests(data_store_ref.path, metadata, self.filemgr_url)
 
     def RTSTelescopeProductRTSIngest(self, metadata):

--- a/scripts/workflowmgr-client.py
+++ b/scripts/workflowmgr-client.py
@@ -57,7 +57,7 @@ if opts.KatFileRTSTesting and product_metadata:
     product_metadata['ReductionName'] = product_metadata['Description']
     xmlrpc_client.workflowmgr.handleEvent('KatFileRTSTesting', product_metadata)
 if opts.RTSTelescopeProductReduce and product_metadata and opts.ReductionName:
-    product_metadata['ReductionName'] = opts.ReductionName
+    product_metadata['ReductionName'] = [opts.ReductionName]
     xmlrpc_client.workflowmgr.handleEvent('RTSTelescopeProductReduce', product_metadata)
 
 if opts.CallExit:


### PR DESCRIPTION
Updates to enable running an rts script from the command line. ReductionName is forced on the command line.

I needed to be able to test the code before deploying to RTSImager machine, so added to the reduction_map is a function called Framework_Testing that is mapped to '0.1', so any call to 0.1 will call this method.

This branch is sync'ed up with the same branch name in katsdpworkflow and should be merged at the same time.

Here is the celery flower output for executing this method. As more methods are needed we can populate the 0.x numbering.

![celery-flower-output](https://cloud.githubusercontent.com/assets/5312913/5701225/e5b6a614-9a50-11e4-8e1a-5daf65f0937d.png)
