### PR TITLE
Include previous sensor value before start of data

### DIFF
--- a/katsdpfilewriter/scripts/file_writer.py
+++ b/katsdpfilewriter/scripts/file_writer.py
@@ -53,7 +53,7 @@ class TelstateModelData(telescope_model.TelescopeModelData):
     def get_sensor_values(self, sensor):
         try:
             values = self._telstate.get_range(sensor.full_name,
-                                              self._start_timestamp, np.inf,
+                                              self._start_timestamp,
                                               include_previous=True)
         except KeyError:
             return None


### PR DESCRIPTION
This is important for event sensors that may change infrequently or not
at all during the observation. The last known value for each sensor is
always passed into the telescope state and might be the only value.
The corresponding timestamp could be hours before the start of the
observation and will be missed by get_range() unless the include_previous
flag is enabled.

Reviewer: @bmerry 
