### PR TITLE
Filewriter chunks

### DIFF
--- a/katsdpfilewriter/katsdpfilewriter/file_writer.py
+++ b/katsdpfilewriter/katsdpfilewriter/file_writer.py
@@ -122,6 +122,7 @@ class File(object):
         """
         ds = self._h5_file.create_dataset(_TIMESTAMPS_DATASET, data=timestamps)
         ds.attrs['timestamp_reference'] = 'centroid'
+        self._h5_file.flush()
 
     def _create_data(self, shape):
         """Creates the data sets for visibilities and flags."""


### PR DESCRIPTION
- Sets chunk size for file to a more sensible (and in particular, writer-friendly) size
- Flush the file after writing the timestamps, to improve the chance of recovering them.
