### PR TITLE
Write telescope state attributes as pickles rather than str()

### DIFF
--- a/katsdpfilewriter/katsdpfilewriter/file_writer.py
+++ b/katsdpfilewriter/katsdpfilewriter/file_writer.py
@@ -100,7 +100,7 @@ def set_telescope_state(h5_file, tstate, base_path=_TSTATE_DATASET):
             tstate_group.create_dataset(key, data=dset)
             logger.debug("TelescopeState: Written {} values for key {} to file".format(len(dset), key))
         else:
-            tstate_group.attrs[key] = str(tstate[key])
+            tstate_group.attrs[key] = tstate.get(key, return_pickle=True)
             logger.debug("TelescopeState: Key {} written as an attribute".format(key))
 
 


### PR DESCRIPTION
This makes it possible to usefully get results back from the attributes in the TelescopeState group of the HDF5 file. This makes it consistent with the handling of sensors, which are also stored as pickles.

@LauraRichter you asked to keep in the loop on this.