### PR TITLE
Get vis_writer ready to run in a container

### DIFF
--- a/katsdpfilewriter/requirements.txt
+++ b/katsdpfilewriter/requirements.txt
@@ -2,13 +2,13 @@ backports-abc
 backports.ssl-match-hostname
 certifi
 Cython
+dask==0.17
 h5py
 fakenewsredis
 funcsigs
 future
 futures
 katcp
-katdal==0.8
 katpoint==0.7
 katversion
 hiredis
@@ -27,9 +27,11 @@ redis
 singledispatch
 six
 spead2
+toolz==0.9.0
 tornado
 traceback2
 trollius
 unittest2
+git+ssh://git@github.com/ska-sa/katdal
 git+ssh://git@github.com/ska-sa/katsdpservices
 git+ssh://git@github.com/ska-sa/katsdptelstate

--- a/katsdpfilewriter/setup.py
+++ b/katsdpfilewriter/setup.py
@@ -18,6 +18,7 @@ setup(
     install_requires=[
         'h5py',
         'numpy',
+        'dask[array]',
         'spead2>=1.5.0',     # For stop_on_stop_item
         'katcp',
         'katdal',


### PR DESCRIPTION
- Add dask to setup.py and requirements.txt
- Remove all references to Ceph, to avoid it trying to read
  /etc/ceph/ceph.conf
- Bump the per-heap logging down to debug level, to avoid spamming the
  logs with hundreds of thousands of messages a day.