### PR TITLE
Remove timestamps from vis writer and add completion token

### DIFF
--- a/katsdpfilewriter/scripts/vis_writer.py
+++ b/katsdpfilewriter/scripts/vis_writer.py
@@ -47,6 +47,7 @@ import threading
 import logging
 import Queue
 import signal
+import subprocess
 from itertools import product
 
 import numpy as np
@@ -228,6 +229,7 @@ class VisibilityWriterServer(DeviceServer):
                                       'chunks': tuple(chunks)}
         telstate_capture.add('chunk_info', full_chunk_info, immutable=True)
         # Touch a token file to indicate that no more chunk data is coming
+        subprocess.call('sync')
         completion_token = os.path.join(self._obj_store.path,
                                         capture_stream_name, 'complete')
         open(completion_token, 'a').close()


### PR DESCRIPTION
The timestamps can now be synthesised from the dump indices, given the sync time, integration time and first timestamp that are all available in telstate since katsdpingest PR [#229](https://github.com/ska-sa/katsdpingest/pull/229). The dump indices also arrive in the L0 SPEAD stream since katsdpingest PR [#220](https://github.com/ska-sa/katsdpingest/pull/220).

Therefore, don't bother synthesising timestamps in vis_writer and writing them explicitly to the chunk store. It is a chunk with a silly size and also critical for opening a data set. It makes much more sense to keep it within telstate and thereby avoid accessing the chunk store for simple things.

Also touch a token file on `capture_done` to indicate completion of the chunk data.