### PR TITLE
Full meta dump

### DIFF
--- a/katsdpmetawriter/scripts/meta_writer.py
+++ b/katsdpmetawriter/scripts/meta_writer.py
@@ -319,7 +319,7 @@ class MetaWriterServer(DeviceServer):
         optionally archive it to the preconfigured S3 endpoint. The precise subset
         is controlled through the selection of capture_block_id, stream_name and
         the lite boolean.
-        Method may take some time so is run asychronously.
+        Method may take some time so is run asynchronously.
 
         Parameters
         ----------


### PR DESCRIPTION
Allow writing a 'full' meta-data dump, by changing the katcp request to ?write-meta <cbid> <lite> <stream_name>.

Currently a 'full' dump is literally the entire telstate at the point of making the write request. In the future this is likely to only include meta-data relevant to the specified cbid and stream name.