### PR TITLE
Remove unused keys from lite RDB

### DIFF
--- a/katsdpmetawriter/scripts/meta_writer.py
+++ b/katsdpmetawriter/scripts/meta_writer.py
@@ -83,7 +83,8 @@ LITE_KEYS = [
     "m???_observer",
     "m???_activity",
     "m???_target",
-    "cbf_target"
+    "cbf_target",
+    "sdp_config"
 ]
 
 


### PR DESCRIPTION
These were previously used to detect the capture block ID and stream
name, which are now explicitly available.