### PR TITLE
 Support receiving vis/flags with ibverbs acceleration 

### DIFF
--- a/katsdpfilewriter/scripts/vis_writer.py
+++ b/katsdpfilewriter/scripts/vis_writer.py
@@ -363,7 +363,7 @@ class VisibilityWriterServer(DeviceServer):
         if self._ibv:
             endpoint_tuples = [(endpoint.host, endpoint.port) for endpoint in self._endpoints]
             self._rx.add_udp_ibv_reader(endpoint_tuples, self._interface_address,
-                                        buffer_size=16 * 1024**2)
+                                        buffer_size=64 * 1024**2)
         else:
             for endpoint in self._endpoints:
                 if self._interface_address is not None:

--- a/katsdpflagwriter/scripts/flag_writer.py
+++ b/katsdpflagwriter/scripts/flag_writer.py
@@ -174,7 +174,7 @@ class FlagWriterServer(DeviceServer):
         if flags_ibv:
             endpoint_tuples = [(endpoint.host, endpoint.port) for endpoint in self._endpoints]
             self._rx.add_udp_ibv_reader(endpoint_tuples, self._interface_address,
-                                        buffer_size=16 * 1024**2)
+                                        buffer_size=64 * 1024**2)
         else:
             for endpoint in self._endpoints:
                 if self._interface_address is not None:


### PR DESCRIPTION
Also threw in MEMCPY_NONTEMPORAL since the heaps are larger than L3 cache
in the cases where performance matters, and this will improve
performance and reduce cache pollution.