### PR TITLE
Write pickles as HDF5 binary strings

### DIFF
--- a/katsdpfilewriter/katsdpfilewriter/file_writer.py
+++ b/katsdpfilewriter/katsdpfilewriter/file_writer.py
@@ -112,12 +112,12 @@ def set_telescope_state(h5_file, tstate, base_path=_TSTATE_DATASET, start_timest
                                              include_previous=True, return_pickle=True)
              # retrieve all values for a particular key
             # swap value, timestamp to timestamp, value
-            sensor_values = [(timestamp, value) for (value, timestamp) in sensor_values]
+            sensor_values = [(timestamp, np.void(value)) for (value, timestamp) in sensor_values]
             dset = np.rec.fromrecords(sensor_values, names='timestamp,value')
             tstate_group.create_dataset(key, data=dset)
             logger.debug("TelescopeState: Written {} values for key {} to file".format(len(dset), key))
         else:
-            tstate_group.attrs[key] = tstate.get(key, return_pickle=True)
+            tstate_group.attrs[key] = np.void(tstate.get(key, return_pickle=True))
             logger.debug("TelescopeState: Key {} written as an attribute".format(key))
 
 


### PR DESCRIPTION
This paves the way for telstate to use binary pickles in future.

See SR-675 and
http://docs.h5py.org/en/latest/strings.html#how-to-store-raw-binary-data

Note that ska-sa/katdal#134 is needed to safely load these files.