### PR TITLE
Fix incorrect use of string as katcp status

### DIFF
--- a/katsdpfilewriter/scripts/file_writer.py
+++ b/katsdpfilewriter/scripts/file_writer.py
@@ -192,7 +192,7 @@ class FileWriterServer(DeviceServer):
                                        free_space)
                     self._rx.stop()
                     end_status = "disk-full"
-                    self._device_status_sensor.set_value("fail", "error")
+                    self._device_status_sensor.set_value("fail", Sensor.ERROR)
         except Exception as err:
             self._logger.error(err)
             end_status = "error"


### PR DESCRIPTION
This was causing exceptions inside katcp when it tried to send out the
sensor update.