### PR TITLE
Build psrchive from docker-base-gpu-build

### DIFF
--- a/psrchive/Dockerfile
+++ b/psrchive/Dockerfile
@@ -9,7 +9,7 @@
 FROM sdp-docker-registry.kat.ac.za:5000/docker-base-gpu-build:latest
 
 
-MAINTAINER Maciej Serylak "mserylak@ska.ac.za"
+MAINTAINER Christopher Schollar "cscollar@ska.ac.za"
 
 
 # Switch account to root and adding user accounts and password


### PR DESCRIPTION
Because the new docker-base-gpu-build image doesn't activate a specific
Python ve itself, added ENV commands to do so.

Note that docker-base-gpu-build has some upgrades, particularly to pip
10 and CUDA 9.1 that may affect things. I've tested that this compiles,
but not that it works since I don't know how to use it.