### PR TITLE
Make stream_name and capture_block_id immutable

### DIFF
--- a/katsdpmetawriter/scripts/meta_writer.py
+++ b/katsdpmetawriter/scripts/meta_writer.py
@@ -164,8 +164,8 @@ def _write_rdb(ctx, telstate, dump_filename, capture_block_id, stream_name, boto
     temp_telstate = katsdptelstate.TelescopeState()
     # Clear since the fake redis backend is a singleton
     temp_telstate.clear()
-    temp_telstate.add('stream_name', stream_name)
-    temp_telstate.add('capture_block_id', capture_block_id)
+    temp_telstate.add('stream_name', stream_name, immutable=True)
+    temp_telstate.add('capture_block_id', capture_block_id, immutable=True)
 
     rdbw = RDBWriter(client=telstate._r)
     supplemental_dumps = rdbw.encode_supplemental_keys(temp_telstate._r, temp_telstate.keys())


### PR DESCRIPTION
These are special attributes written to indicate to katdal which stream
and capture_block_id are of interest in a file. However, they were being
written as sensors, which caused them to be put in the katdal sensor
cache, where they don't work because of SR-1303.