### PR TITLE
 Add option for datawriter to write straight to S3

### DIFF
--- a/katsdpdatawriter/katsdpdatawriter/test/test_spead_write.py
+++ b/katsdpdatawriter/katsdpdatawriter/test/test_spead_write.py
@@ -8,7 +8,7 @@ from aiokatcp import SensorSet
 from katdal.chunkstore import ChunkStore
 
 from ..spead_write import (Array, RechunkerGroup, io_sensors,
-                           add_chunk_store_args, chunk_store_from_args)
+                           add_common_args, chunk_store_from_args)
 from ..rechunk import Offset
 from ..bounded_executor import BoundedThreadPoolExecutor
 
@@ -131,7 +131,7 @@ class BadArguments(Exception):
 class TestChunkStoreFromArgs:
     def setup(self) -> None:
         self.parser = argparse.ArgumentParser()
-        add_chunk_store_args(self.parser)
+        add_common_args(self.parser)
 
     def test_missing_args(self, error):
         with assert_raises(BadArguments):

--- a/katsdpdatawriter/scripts/flag_writer.py
+++ b/katsdpdatawriter/scripts/flag_writer.py
@@ -17,7 +17,7 @@ import katsdptelstate
 import katsdpservices
 
 from katsdpdatawriter.flag_writer import FlagWriterServer
-from katsdpdatawriter.spead_write import add_chunk_store_args, chunk_store_from_args
+from katsdpdatawriter.spead_write import add_common_args, chunk_store_from_args
 
 
 def on_shutdown(loop: asyncio.AbstractEventLoop, server: FlagWriterServer) -> None:
@@ -41,7 +41,7 @@ if __name__ == '__main__':
     katsdpservices.setup_restart()
 
     parser = katsdpservices.ArgumentParser()
-    add_chunk_store_args(parser)
+    add_common_args(parser)
     parser.add_argument('--flags-spead', default=':7202', metavar='ENDPOINTS',
                         type=katsdptelstate.endpoint.endpoint_list_parser(7202),
                         help='Source port/multicast groups for flags SPEAD streams. '
@@ -53,18 +53,7 @@ if __name__ == '__main__':
                         help='name for the flags stream. [default=%(default)s]', metavar='NAME')
     parser.add_argument('--flags-ibv', action='store_true',
                         help='Use ibverbs acceleration to receive flags')
-    parser.add_argument('--workers', type=int, default=50,
-                        help='Threads to use for writing chunks')
-    parser.add_argument('--no-aiomonitor', dest='aiomonitor', action='store_false',
-                        help='Disable aiomonitor debugging server')
-    parser.add_argument('--aiomonitor-port', type=int, default=aiomonitor.MONITOR_PORT,
-                        help='port for aiomonitor [default=%(default)s]')
-    parser.add_argument('--aioconsole-port', type=int, default=aiomonitor.CONSOLE_PORT,
-                        help='port for aioconsole [default=%(default)s]')
-    parser.add_argument('-p', '--port', type=int, default=2052, metavar='N',
-                        help='KATCP host port [default=%(default)s]')
-    parser.add_argument('-a', '--host', default="", metavar='HOST',
-                        help='KATCP host address [default=all hosts]')
+    parser.set_defaults(telstate='localhost', port=2052)
 
     args = parser.parse_args()
     if args.telstate is None:
@@ -75,7 +64,8 @@ if __name__ == '__main__':
     chunk_store = chunk_store_from_args(parser, args)
     loop = asyncio.get_event_loop()
     server = FlagWriterServer(args.host, args.port, loop, args.flags_spead,
-                              args.flags_interface, args.flags_ibv, chunk_store,
+                              args.flags_interface, args.flags_ibv,
+                              chunk_store, args.obj_size_mb * 1e6,
                               args.telstate, args.flags_name, args.workers)
 
     if args.aiomonitor:

--- a/katsdpdatawriter/scripts/vis_writer.py
+++ b/katsdpdatawriter/scripts/vis_writer.py
@@ -9,7 +9,7 @@ import katsdpservices
 import katsdptelstate
 
 from katsdpdatawriter.vis_writer import VisibilityWriterServer
-from katsdpdatawriter.spead_write import add_chunk_store_args, chunk_store_from_args
+from katsdpdatawriter.spead_write import add_common_args, chunk_store_from_args
 
 
 def on_shutdown(loop: asyncio.AbstractEventLoop, server: VisibilityWriterServer) -> None:
@@ -33,7 +33,7 @@ if __name__ == '__main__':
     katsdpservices.setup_restart()
 
     parser = katsdpservices.ArgumentParser()
-    add_chunk_store_args(parser)
+    add_common_args(parser)
     parser.add_argument('--l0-spead', default=':7200', metavar='ENDPOINTS',
                         type=katsdptelstate.endpoint.endpoint_list_parser(7200),
                         help='Source port/multicast groups for L0 SPEAD stream. '
@@ -45,21 +45,7 @@ if __name__ == '__main__':
                         help='Name of L0 stream from ingest [default=%(default)s]')
     parser.add_argument('--l0-ibv', action='store_true',
                         help='Use ibverbs acceleration to receive L0 stream [default=no]')
-    parser.add_argument('--obj-size-mb', type=float, default=10., metavar='MB',
-                        help='Target object size in MB [default=%(default)s]')
-    parser.add_argument('--workers', type=int, default=50,
-                        help='Threads to use for writing chunks')
-    parser.add_argument('--no-aiomonitor', dest='aiomonitor', action='store_false',
-                        help='Disable aiomonitor debugging server')
-    parser.add_argument('--aiomonitor-port', type=int, default=aiomonitor.MONITOR_PORT,
-                        help='port for aiomonitor [default=%(default)s]')
-    parser.add_argument('--aioconsole-port', type=int, default=aiomonitor.CONSOLE_PORT,
-                        help='port for aioconsole [default=%(default)s]')
-    parser.add_argument('-p', '--port', type=int, default=2046, metavar='N',
-                        help='KATCP host port [default=%(default)s]')
-    parser.add_argument('-a', '--host', default="", metavar='HOST',
-                        help='KATCP host address [default=all hosts]')
-    parser.set_defaults(telstate='localhost')
+    parser.set_defaults(telstate='localhost', port=2046)
     args = parser.parse_args()
 
     if args.l0_ibv and args.l0_interface is None:


### PR DESCRIPTION
- Unify the code for setting up the chunk store between vis_writer and
  flag_writer.
- Add --s3-access-key and --s3-secret-key to provide credentials
- Make --npy-path optional, switching to S3 chunk store if not given and
  the other arguments are given.