### PR TITLE
Correct the heap size computation for datawriter

### DIFF
--- a/katsdpdatawriter/katsdpdatawriter/spead_write.py
+++ b/katsdpdatawriter/katsdpdatawriter/spead_write.py
@@ -412,7 +412,7 @@ def make_receiver(endpoints: Sequence[Endpoint],
                                     ring_heaps=ring_heaps,
                                     contiguous_only=False)
     n_memory_buffers = max_heaps + ring_heaps + 2
-    heap_size = sum(a.nbytes for a in arrays)
+    heap_size = sum(a.nbytes // a.substreams for a in arrays)
     memory_pool = spead2.MemoryPool(heap_size, heap_size + 4096,
                                     n_memory_buffers, n_memory_buffers)
     rx.set_memory_pool(memory_pool)


### PR DESCRIPTION
It was computing the size of a full dump (i.e. sum across substreams).
Fix it by dividing by the number of substreams.