### PR TITLE
Allow stream renaming as part of data writing

### DIFF
--- a/katsdpdatawriter/katsdpdatawriter/test/test_spead_write.py
+++ b/katsdpdatawriter/katsdpdatawriter/test/test_spead_write.py
@@ -129,6 +129,7 @@ class BadArguments(Exception):
 
 @mock.patch.object(argparse.ArgumentParser, 'error', side_effect=BadArguments)
 class TestChunkStoreFromArgs:
+    """Test both :meth:`.add_common_args` and :meth:`.chunk_store_from_args`"""
     def setup(self) -> None:
         self.parser = argparse.ArgumentParser()
         add_common_args(self.parser)
@@ -160,3 +161,13 @@ class TestChunkStoreFromArgs:
                 ['--s3-endpoint-url=https://s3.invalid',
                  '--s3-secret-key=S3CR3T', '--s3-access-key', 'ACCESS']))
         m.assert_called_with('https://s3.invalid', credentials=('ACCESS', 'S3CR3T'))
+
+    def test_rename_src(self, error):
+        args = self.parser.parse_args([
+            '--rename-src=foo:bar', '--rename-src', 'x:y',
+            '--new-name', 'xyz'])
+        assert_equal(args.rename_src, {'foo': 'bar', 'x': 'y'})
+
+    def test_rename_src_bad_colons(self, error):
+        with assert_raises(BadArguments):
+            self.parser.parse_args(['--rename-src=foo:bar:baz', '--new-name', 'xyz'])

--- a/katsdpdatawriter/katsdpdatawriter/test/test_writer.py
+++ b/katsdpdatawriter/katsdpdatawriter/test/test_writer.py
@@ -15,8 +15,8 @@ from nose.tools import assert_equal, assert_in
 
 class BaseTestWriterServer(asynctest.TestCase):
     @classmethod
-    def setup_telstate(cls) -> katsdptelstate.TelescopeState:
-        telstate = katsdptelstate.TelescopeState()
+    def setup_telstate(cls, namespace: str) -> katsdptelstate.TelescopeState:
+        telstate = katsdptelstate.TelescopeState().view(namespace)
         n_ants = 3
         telstate.add('n_chans', 4096, immutable=True)
         telstate.add('n_chans_per_substream', 1024, immutable=True)

--- a/katsdpdatawriter/scripts/flag_writer.py
+++ b/katsdpdatawriter/scripts/flag_writer.py
@@ -60,13 +60,19 @@ if __name__ == '__main__':
         parser.error('--telstate is required')
     if args.flags_ibv and args.flags_interface is None:
         parser.error("--flags-ibv requires --flags-interface")
+    if args.rename_src and args.new_name is None:
+        parser.error('--rename-src requires --new-name')
 
     chunk_store = chunk_store_from_args(parser, args)
     loop = asyncio.get_event_loop()
     server = FlagWriterServer(args.host, args.port, loop, args.flags_spead,
                               args.flags_interface, args.flags_ibv,
                               chunk_store, args.obj_size_mb * 1e6,
-                              args.telstate, args.flags_name, args.workers)
+                              args.telstate,
+                              args.flags_name,
+                              args.new_name if args.new_name is not None else args.flags_name,
+                              args.rename_src, args.s3_endpoint_url,
+                              args.workers)
 
     if args.aiomonitor:
         with aiomonitor.start_monitor(loop=loop,

--- a/katsdpdatawriter/scripts/vis_writer.py
+++ b/katsdpdatawriter/scripts/vis_writer.py
@@ -50,18 +50,21 @@ if __name__ == '__main__':
 
     if args.l0_ibv and args.l0_interface is None:
         parser.error('--l0-ibv requires --l0-interface')
+    if args.rename_src and args.new_name is None:
+        parser.error('--rename-src requires --new-name')
 
-    # Connect to object store and save config in telstate
+    # Connect to object store
     chunk_store = chunk_store_from_args(parser, args)
-    telstate_l0 = args.telstate.view(args.l0_name)
-    if args.s3_endpoint_url:
-        telstate_l0.add('s3_endpoint_url', args.s3_endpoint_url, immutable=True)
-
     loop = asyncio.get_event_loop()
     server = VisibilityWriterServer(args.host, args.port, loop, args.l0_spead,
                                     args.l0_interface, args.l0_ibv,
                                     chunk_store, args.obj_size_mb * 1e6,
-                                    telstate_l0, args.l0_name, args.workers)
+                                    args.telstate,
+                                    args.l0_name,
+                                    args.new_name if args.new_name is not None else args.l0_name,
+                                    args.rename_src,
+                                    args.s3_endpoint_url,
+                                    args.workers)
 
     if args.aiomonitor:
         with aiomonitor.start_monitor(loop=loop,


### PR DESCRIPTION
- Add --new-name argument to specify new name for the output stream.
  Telstate will be updated with <stream>_inherit to point back at the
  original stream.
- Add --rename-src to allow rewriting on src_streams when --new-name is
  used.
- Make flag_writer write s3_endpoint_url to telstate, consistently with
  vis_writer.
- Fix vis_writer writing chunk_info as mutable.

See SR-1348 for design details.