### PR TITLE
Remove chunk_name from LITE_KEYS in metawriter

### DIFF
--- a/katsdpmetawriter/scripts/meta_writer.py
+++ b/katsdpmetawriter/scripts/meta_writer.py
@@ -74,7 +74,6 @@ LITE_KEYS = [
     "{cb}_obs_script_log",
     "{cb}_obs_label",
     "{cb}_obs_activity",
-    "{cb}_{sn}_chunk_name",
     "{cb}_{sn}_chunk_info",
     "{cb}_{sn}_first_timestamp",
     "sub_pool_resources",


### PR DESCRIPTION
The chunk_name telstate key was removed from datawriter some time ago
(replaced by chunk_info.prefix), but metawriter was still trying to grab
it and spewing out errors as a result.