### PR TITLE
Capture need_weights_power_scale into light dump

### DIFF
--- a/katsdpmetawriter/scripts/meta_writer.py
+++ b/katsdpmetawriter/scripts/meta_writer.py
@@ -70,6 +70,7 @@ LITE_KEYS = [
     "{sn}_center_freq",
     "{sn}_s3_endpoint_url",
     "{sn}_stream_type",
+    "{sn}_need_weights_power_scale",
     "{cb}_obs_params",
     "{cb}_obs_script_log",
     "{cb}_obs_label",


### PR DESCRIPTION
It's needed for katdal to read the data correctly. It will probably log
errors on the sdp_l1_flags stream (which won't have it), but cleaning up
these errors is a task for another day.

This relates to SR-1230.