### PR TITLE
Disable the dashboard by default

### DIFF
--- a/katsdpdatawriter/katsdpdatawriter/spead_write.py
+++ b/katsdpdatawriter/katsdpdatawriter/spead_write.py
@@ -584,10 +584,8 @@ def add_common_args(parser: argparse.ArgumentParser) -> None:
     group.add_argument('--aioconsole-port', type=int,
                        default=aiomonitor.CONSOLE_PORT, metavar='PORT',
                        help='Port for aioconsole [%(default)s]')
-    group.add_argument('--no-dashboard', dest='dashboard', action='store_false',
-                       help='Disable dashboard')
-    group.add_argument('--dashboard-port', type=int, default=5006, metavar='PORT',
-                       help='Port for dashboard [(default)s]')
+    group.add_argument('--dashboard-port', type=int, metavar='PORT',
+                       help='Port for dashboard [disabled]')
     group.add_argument('--external-hostname', default=socket.getfqdn(), metavar='HOSTNAME',
                        help='Hostname through which the dashboard will be accessed [%(default)s]')
     group.add_argument('--dashboard-allow-websocket-origin', action='append', metavar='ORIGIN',

--- a/katsdpdatawriter/scripts/flag_writer.py
+++ b/katsdpdatawriter/scripts/flag_writer.py
@@ -74,7 +74,7 @@ if __name__ == '__main__':
                               args.new_name if args.new_name is not None else args.flags_name,
                               args.rename_src, args.s3_endpoint_url,
                               args.workers)
-    if args.dashboard:
+    if args.dashboard_port is not None:
         dashboard = make_dashboard(server.sensors)
         start_dashboard(dashboard, args)
 

--- a/katsdpdatawriter/scripts/vis_writer.py
+++ b/katsdpdatawriter/scripts/vis_writer.py
@@ -66,7 +66,7 @@ if __name__ == '__main__':
                                     args.rename_src,
                                     args.s3_endpoint_url,
                                     args.workers)
-    if args.dashboard:
+    if args.dashboard_port is not None:
         dashboard = make_dashboard(server.sensors)
         start_dashboard(dashboard, args)
 


### PR DESCRIPTION
It turns out to require excessive time/resources which prevent
full-speed capture. Now one can explicitly enable it by passing a
dashboard port.

This will also need a master controller change to avoid passing a
dashboard port.