### PR TITLE
Make mypy happy again

### DIFF
--- a/katsdpdatawriter/katsdpdatawriter/spead_write.py
+++ b/katsdpdatawriter/katsdpdatawriter/spead_write.py
@@ -493,7 +493,7 @@ def make_receiver(endpoints: Sequence[Endpoint],
                   interface_address: Optional[str],
                   ibv: bool,
                   max_heaps_per_substream: int = 2,
-                  ring_heaps_per_substream: int = 2):
+                  ring_heaps_per_substream: int = 2) -> spead2.recv.asyncio.Stream:
     """Generate a SPEAD receiver suitable for :class:`SpeadWriter`.
 
     Parameters
@@ -527,6 +527,8 @@ def make_receiver(endpoints: Sequence[Endpoint],
     rx.set_memcpy(spead2.MEMCPY_NONTEMPORAL)
     rx.stop_on_stop_item = False
     if ibv:
+        # The main scripts check this; the assert keeps mypy happy
+        assert interface_address is not None, "Interface address is required when using ibverbs"
         endpoint_tuples = [(endpoint.host, endpoint.port) for endpoint in endpoints]
         rx.add_udp_ibv_reader(endpoint_tuples, interface_address,
                               buffer_size=64 * 1024**2)

--- a/katsdpdatawriter/katsdpdatawriter/test/test_writer.py
+++ b/katsdpdatawriter/katsdpdatawriter/test/test_writer.py
@@ -10,6 +10,7 @@ from katsdptelstate.endpoint import Endpoint
 import aiokatcp
 import spead2
 import spead2.recv.asyncio
+import spead2.send.asyncio
 from nose.tools import assert_equal, assert_in
 
 


### PR DESCRIPTION
The latest spead2 has type annotations, which allowed mypy to pick up
some extra errors. None of them were real bugs, but there were missing
annotations that it needed to be happy.