### PR TITLE
Record chunk_info dtype as string not object

### DIFF
--- a/katsdpdatawriter/katsdpdatawriter/rechunk.py
+++ b/katsdpdatawriter/katsdpdatawriter/rechunk.py
@@ -298,7 +298,7 @@ class Rechunker:
         """
         return {
             'prefix': prefix,
-            'dtype': self.dtype,
+            'dtype': np.lib.format.dtype_to_descr(self.dtype),
             'shape': self._get_shape(),
             'chunks': self._get_chunks()
         }

--- a/katsdpdatawriter/katsdpdatawriter/test/test_spead_write.py
+++ b/katsdpdatawriter/katsdpdatawriter/test/test_spead_write.py
@@ -111,13 +111,13 @@ class TestRechunkerGroup(asynctest.TestCase):
                     'prefix': 'prefix',
                     'chunks': ((1, 1), (2, 2, 2, 2), (2,)),
                     'shape': (2, 8, 2),
-                    'dtype': np.uint8
+                    'dtype': '|u1'
                 },
                 'weights_channel': {
                     'prefix': 'prefix',
                     'chunks': ((2,), (2, 2, 2, 2)),
                     'shape': (2, 8),
-                    'dtype': np.float32
+                    'dtype': '<f4'      # TODO: assumes little-endian hardware
                 }
             })
 


### PR DESCRIPTION
msgpack doesn't support encoding dtype objects, so store the string
representation instead.