### PR TITLE
Stop supporting aiokatcp<0.5

### DIFF
--- a/katsdpdatawriter/katsdpdatawriter/test/test_spead_write.py
+++ b/katsdpdatawriter/katsdpdatawriter/test/test_spead_write.py
@@ -47,11 +47,7 @@ class TestRechunkerGroup(asynctest.TestCase):
         self.chunk_store = mock.create_autospec(spec=ChunkStore, spec_set=True, instance=True)
         self.chunk_store.join = _join
 
-        try:
-            self.sensors = SensorSet()
-        except TypeError:
-            # Prior to aiokatcp 0.5 it needed a set of connections
-            self.sensors = SensorSet(set())
+        self.sensors = SensorSet()
         for sensor in io_sensors():
             self.sensors.add(sensor)
 

--- a/katsdpdatawriter/setup.py
+++ b/katsdpdatawriter/setup.py
@@ -16,7 +16,7 @@ setup(
     ],
     setup_requires=["katversion"],
     install_requires=[
-        "aiokatcp>=0.3.0",     # Needed for status_func
+        "aiokatcp>=0.5.0",     # Needed for change to SensorSet constructor
         "spead2>=1.8.0",       # Needed for async iteration
         "katsdptelstate",
         "katsdpservices[argparse,aiomonitor]",


### PR DESCRIPTION
I've bumped katsdpdockerbase to aiokatcp 0.5.0, so there is no more need
to support the older version, and it was causing a mypy failure because
one of the two branches would always be flagged as the wrong number of
parameters.