### PR TITLE
Modernise use of katsdptelstate

### DIFF
--- a/katsdpdatawriter/katsdpdatawriter/flag_writer.py
+++ b/katsdpdatawriter/katsdpdatawriter/flag_writer.py
@@ -192,7 +192,7 @@ class FlagWriterServer(DeviceServer):
         chunk_info = await rechunker_group.get_chunk_info()
         capture_stream_name = self._get_capture_stream_name(capture_block_id)
         telstate_capture = self._telstate.view(capture_stream_name)
-        telstate_capture.add('chunk_info', chunk_info, immutable=True)
+        telstate_capture['chunk_info'] = chunk_info
         logger.info("Written chunk information to telstate.", extra=extra)
 
     async def request_capture_done(self, ctx, capture_block_id: str) -> None:

--- a/katsdpdatawriter/katsdpdatawriter/spead_write.py
+++ b/katsdpdatawriter/katsdpdatawriter/spead_write.py
@@ -514,14 +514,14 @@ def write_telstate(telstate: katsdptelstate.TelescopeState,
     """Write telstate information about output stream."""
     telstate_out = telstate.view(output_name)
     if output_name != input_name:
-        telstate_out.add('inherit', input_name, immutable=True)
+        telstate_out['inherit'] = input_name
         if rename_src:
             telstate_in = telstate.view(input_name)
             src_streams_in = telstate_in['src_streams']
             src_streams_out = [rename_src.get(stream, stream) for stream in src_streams_in]
-            telstate_out.add('src_streams', src_streams_out, immutable=True)
+            telstate_out['src_streams'] = src_streams_out
     if s3_endpoint_url is not None:
-        telstate_out.add('s3_endpoint_url', s3_endpoint_url, immutable=True)
+        telstate_out['s3_endpoint_url'] = s3_endpoint_url
 
 
 def make_receiver(endpoints: Sequence[Endpoint],

--- a/katsdpdatawriter/katsdpdatawriter/test/test_flag_writer.py
+++ b/katsdpdatawriter/katsdpdatawriter/test/test_flag_writer.py
@@ -68,7 +68,7 @@ class TestFlagWriterServer(BaseTestWriterServer):
         self.addCleanup(shutil.rmtree, self.npy_path)
         self.chunk_store = NpyFileChunkStore(self.npy_path)
         self.telstate = self.setup_telstate('sdp_l1_flags')
-        self.telstate.add('src_streams', ['sdp_l0'], immutable=True)
+        self.telstate['src_streams'] = ['sdp_l0']
         self.chunk_channels = 128
         self.chunk_params = ChunkParams(self.telstate['n_bls'] * self.chunk_channels,
                                         self.chunk_channels)

--- a/katsdpdatawriter/katsdpdatawriter/test/test_vis_writer.py
+++ b/katsdpdatawriter/katsdpdatawriter/test/test_vis_writer.py
@@ -75,7 +75,7 @@ class TestVisWriterServer(BaseTestWriterServer):
         self.addCleanup(shutil.rmtree, npy_path)
         self.chunk_store = katdal.chunkstore_npy.NpyFileChunkStore(npy_path)
         self.telstate = self.setup_telstate('sdp_l0')
-        self.telstate.add('src_streams', ['i0_baseline_correlation_products'], immutable=True)
+        self.telstate['src_streams'] = ['i0_baseline_correlation_products']
         self.setup_sleep()
         self.setup_spead()
         self.server = await self.setup_server()

--- a/katsdpdatawriter/katsdpdatawriter/test/test_writer.py
+++ b/katsdpdatawriter/katsdpdatawriter/test/test_writer.py
@@ -19,9 +19,9 @@ class BaseTestWriterServer(asynctest.TestCase):
     def setup_telstate(cls, namespace: str) -> katsdptelstate.TelescopeState:
         telstate = katsdptelstate.TelescopeState().view(namespace)
         n_ants = 3
-        telstate.add('n_chans', 4096, immutable=True)
-        telstate.add('n_chans_per_substream', 1024, immutable=True)
-        telstate.add('n_bls', n_ants * (n_ants + 1) * 2, immutable=True)
+        telstate['n_chans'] = 4096
+        telstate['n_chans_per_substream'] = 1024
+        telstate['n_bls'] = n_ants * (n_ants + 1) * 2
         return telstate
 
     def setup_sleep(self) -> None:

--- a/katsdpdatawriter/katsdpdatawriter/vis_writer.py
+++ b/katsdpdatawriter/katsdpdatawriter/vis_writer.py
@@ -155,7 +155,7 @@ class VisibilityWriterServer(DeviceServer):
 
             self.sensors['status'].value = Status.FINALISING
             view = self._telstate.view(capture_stream_name)
-            view.add('chunk_info', await rechunker_group.get_chunk_info(), immutable=True)
+            view['chunk_info'] = await rechunker_group.get_chunk_info()
             rechunker_group = None   # Tells except block not to clean up
             self._chunk_store.mark_complete(prefix)
             self.sensors['status'].value = Status.COMPLETE
@@ -178,8 +178,7 @@ class VisibilityWriterServer(DeviceServer):
             raise FailReply('Already capturing')
         self.sensors['status'].value = Status.WAIT_DATA
         self.sensors['device-status'].value = spead_write.DeviceStatus.OK
-        sep = self._telstate.SEPARATOR
-        capture_stream_name = sep.join((capture_block_id, self._output_name))
+        capture_stream_name = self._telstate.join(capture_block_id, self._output_name)
         self._rx = spead_write.make_receiver(
             self._endpoints, self._arrays, self._interface_address, self._ibv)
         self._capture_task = self.loop.create_task(self._do_capture(capture_stream_name, self._rx))


### PR DESCRIPTION
- Use telstate.join instead of telstate.SEPARATOR
- Use item set instead of add with immutable=True