### PR TITLE
Build against legacy Python2-supporting katsdpdockerbase

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,4 +1,4 @@
-FROM sdp-docker-registry.kat.ac.za:5000/docker-base-build
+FROM sdp-docker-registry.kat.ac.za:5000/docker-base-build:python2
 
 MAINTAINER Thomas Bennett "tbennett@ska.ac.za"
 

--- a/Jenkinsfile
+++ b/Jenkinsfile
@@ -3,7 +3,7 @@
 @Library('katsdpjenkins') _
 
 katsdp.killOldJobs()
-katsdp.setDependencies(['ska-sa/katsdpdockerbase/master',
+katsdp.setDependencies(['ska-sa/katsdpdockerbase/python2',
                         'ska-sa/katdal/master', 'ska-sa/katpoint/master',
                         'ska-sa/katsdpservices/master',
                         'ska-sa/katsdptelstate/master'])


### PR DESCRIPTION
I'm planning to remove Python 2 support from katsdpdockerbase master, and keep a legacy "python2" branch for the packages that haven't migrated to Python 3 yet.