### PR TITLE
Use python2 legacy branch of katsdpjenkins

### DIFF
--- a/Jenkinsfile
+++ b/Jenkinsfile
@@ -1,6 +1,6 @@
 #!groovy
 
-@Library('katsdpjenkins') _
+@Library('katsdpjenkins@python2') _
 
 katsdp.killOldJobs()
 katsdp.setDependencies(['ska-sa/katsdpdockerbase/python2',


### PR DESCRIPTION
I'd like to simplify katsdpjenkins by removing Python 2 support, so this is to keep katsdpdata working (since it still uses Python 2).