### PR TITLE
Use quay.io for base image by default

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,6 +1,7 @@
-FROM sdp-docker-registry.kat.ac.za:5000/docker-base-build
+ARG KATSDPDOCKERBASE_REGISTRY=quay.io/ska-sa
 
-MAINTAINER Thomas Bennett "tbennett@ska.ac.za"
+FROM $KATSDPDOCKERBASE_REGISTRY/docker-base-build as build
+LABEL maintainer="Thomas Bennett <tbennett@ska.ac.za>"
 
 # Suppress debconf warnings
 ENV DEBIAN_FRONTEND noninteractive


### PR DESCRIPTION
This allows the image to be built from anywhere.

Also replaced deprecated MAINTAINER with a label (see
https://docs.docker.com/engine/reference/builder/#maintainer-deprecated).