### PR TITLE
Add wheel to pyproject.toml

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,3 +1,3 @@
 [build-system]
 # Minimum requirements for the build system to execute
-requires = ["setuptools", "katversion"]
+requires = ["setuptools", "wheel", "katversion"]


### PR DESCRIPTION
Without it, pip complains:
```
  WARNING: Missing build requirements in pyproject.toml for
file:///tmp/install/katsdpdata.
  WARNING: The project does not specify a build backend, and pip cannot
fall back to setuptools without 'wheel'.
```