### PR TITLE
Handling S3 unavailability during metadata update.

### DIFF
--- a/katsdpdata/met_handler.py
+++ b/katsdpdata/met_handler.py
@@ -127,6 +127,8 @@ class MetDataHandlerSuper:
         return self.get_prod_met(met['id'])
 
     def add_bucket_stats(self, met, bucket_met):
+        if not bucket_met:
+            return self.get_prod_met(met['id'])
         met.update(bucket_met)
         self.solr.add([met], commit=True)
         return self.get_prod_met(met['id'])


### PR DESCRIPTION
# Problem

When the bucketstats aren't available the met update breaks. 

# Solution

Ignore empty s3 update request (we can't do anything else here anyway.)