### PR TITLE
SPR1-2766: Upgrade packages to latest versions

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -1,9 +1,9 @@
 -c https://raw.githubusercontent.com/ska-sa/katsdpdockerbase/master/docker-base-build/base-requirements.txt
 
-boto==2.48.0
-katdal==0.16
-katpoint==0.9
-katsdpservices==1.0
-katsdptelstate==0.10
+boto==2.49.0
+katdal==0.20.1
+katpoint==0.10
+katsdpservices==1.2
+katsdptelstate==0.13
 numpy
-pysolr==3.3.3
+pysolr==3.9.0


### PR DESCRIPTION
We moved to katsdptelstate 0.13 today. Katsdpdockerbase will host the redis and fakeredis versions that go along with it, so it's best if all packages based on that move to 0.13.

Use the opportunity to bump all the packages to the latest versions (first time in five years!). Holding thumbs...