### PR TITLE
Ensure bucket does not exist when running create

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -19,7 +19,7 @@ COPY --chown=kat:kat requirements.txt /tmp/install/requirements.txt
 RUN install_pinned.py -r /tmp/install/requirements.txt
 
 # Install the current package
-COPY . /tmp/install/katsdpdata
+COPY --chown=kat:kat . /tmp/install/katsdpdata
 WORKDIR /tmp/install/katsdpdata
 RUN python ./setup.py clean
 RUN pip install --no-deps .

--- a/katsdpdata/met_extractors.py
+++ b/katsdpdata/met_extractors.py
@@ -100,7 +100,7 @@ class TelescopeProductMetExtractor(MetExtractor):
     def _extract_metadata_from_katdata(self):
         """Populate self.metadata: Get information using katdal"""
         self.metadata['Antennas'] = [a.name for a in self._katdata.ants]
-        center_freq = self._katdata.channel_freqs[floor(self._katdata.channels[-1]/2)]
+        center_freq = self._katdata.spectral_windows[self._katdata.spw].centre_freq
         self.metadata['CenterFrequency'] = "{:.2f}".format(center_freq)
         self.metadata['ChannelWidth'] = str(self._katdata.channel_width)
         self.metadata['MinFreq'] = str(min(self._katdata.freqs))

--- a/katsdpdata/prod_handler.py
+++ b/katsdpdata/prod_handler.py
@@ -51,8 +51,10 @@ class Uploader:
         """
         s3_bucket_policy = s3_create_anon_access_policy(bucket_name)
         try:
-            s3_bucket = s3_conn.create_bucket(bucket_name)
-            s3_bucket.set_policy(s3_bucket_policy)
+            s3_bucket = s3_conn.lookup(bucket_name)
+            if s3_bucket is None:
+                s3_bucket = s3_conn.create_bucket(bucket_name)
+                s3_bucket.set_policy(s3_bucket_policy)
         except boto.exception.S3ResponseError as e:
             if e.status == 403 or e.status == 409:
                 logger.error(

--- a/katsdpdata/prod_handler.py
+++ b/katsdpdata/prod_handler.py
@@ -53,6 +53,7 @@ class Uploader:
         try:
             s3_bucket = s3_conn.lookup(bucket_name)
             if s3_bucket is None:
+                logging.info("S3 bucket lookup for %s returned None. Creating bucket and setting policy.", bucket_name)
                 s3_bucket = s3_conn.create_bucket(bucket_name)
                 s3_bucket.set_policy(s3_bucket_policy)
         except boto.exception.S3ResponseError as e:


### PR DESCRIPTION
The previous implementation results in multiple polcies being set on the same bucket. Ceph c5 was getting lots of policy timeouts and this should reduce the load on the policy infrastructure in Ceph.